### PR TITLE
Fix ECC calculation code for XeLL update to prevent console brick

### DIFF
--- a/libxenon/drivers/xenon_nand/xenon_sfcx.c
+++ b/libxenon/drivers/xenon_nand/xenon_sfcx.c
@@ -202,7 +202,7 @@ void sfcx_calcecc_ex(unsigned int *data, unsigned char* edc) {
 	val = ~val;
 
 	// 26 bit ecc data
-	edc[0] = ((val << 6) | (data[0x20C] & 0x3F)) & 0xFF;
+	edc[0] = ((val << 6) | (data[0xC] & 0x3F)) & 0xFF;
 	edc[1] = (val >> 2) & 0xFF;
 	edc[2] = (val >> 10) & 0xFF;
 	edc[3] = (val >> 18) & 0xFF;

--- a/libxenon/drivers/xenon_nand/xenon_sfcx.c
+++ b/libxenon/drivers/xenon_nand/xenon_sfcx.c
@@ -202,7 +202,7 @@ void sfcx_calcecc_ex(unsigned int *data, unsigned char* edc) {
 	val = ~val;
 
 	// 26 bit ecc data
-	edc[0] = ((val << 6) | (data[0xC] & 0x3F)) & 0xFF;
+	edc[0] = ((val << 6) | (edc[0] & 0x3F)) & 0xFF;
 	edc[1] = (val >> 2) & 0xFF;
 	edc[2] = (val >> 10) & 0xFF;
 	edc[3] = (val >> 18) & 0xFF;


### PR DESCRIPTION
Reverts ECC calculation data change made by the following commit. Originally it was used for checking images for rawflash but is now only used by updatexell()

https://github.com/Free60Project/libxenon/commit/9aeeefd897f413ddbec4409b6f12cfcd1540d168

Prior to the change in this PR, applying an updxell.bin will brick the console and result in bad block errors re-reading the NAND. Update works as expected after applying the change.