### PR TITLE
Cherry-pick ECC calculation code fix from free60 libxenon

### DIFF
--- a/libxenon/drivers/xenon_nand/xenon_sfcx.c
+++ b/libxenon/drivers/xenon_nand/xenon_sfcx.c
@@ -202,7 +202,7 @@ void sfcx_calcecc_ex(unsigned int *data, unsigned char* edc) {
 	val = ~val;
 
 	// 26 bit ecc data
-	edc[0] = ((val << 6) | (data[0x20C] & 0x3F)) & 0xFF;
+	edc[0] = (val << 6) & 0xFF;
 	edc[1] = (val >> 2) & 0xFF;
 	edc[2] = (val >> 10) & 0xFF;
 	edc[3] = (val >> 18) & 0xFF;


### PR DESCRIPTION
Fix ECC calculation code for XeLL update to prevent console brick